### PR TITLE
Add fastMNN

### DIFF
--- a/R/clusterdeg.R
+++ b/R/clusterdeg.R
@@ -25,6 +25,10 @@
 #'   respectively. The clusters derived from the last value in the list will be 
 #'   set as the default Ident for cells and stored in \code{meta.data} under
 #'   'seurat_clusters' in addition to the aforementioned format.
+#' @param mnn Boolean indicating whether \code{scrna} was integrated with
+#'   \code{method="MNN"} via \code{\link{SimpleIntegration}}. If so, must be set
+#'   to \code{TRUE} or unintegrated PCA embeddings will be used for
+#'   dimensionality reduction and clustering.
 #' @param skip.sct Boolean indicating whether to skip 
 #'   \code{\link[Seurat]{SCTransform}}. Set to TRUE if 
 #'   \code{\link{SimpleIntegration}} was used to integrate the 
@@ -103,7 +107,7 @@ ClusterDEG <- function(scrna, outdir = ".", npcs = 30, res = 0.8, mnn = FALSE,
   } else {
     reduc <- "mnn"
   }
-  message("Using ", reduction, " reduction.")
+  message("Using ", reduc, " reduction.")
 
   scrna <- RunPCA(scrna, npcs = npcs)
   scrna <- RunTSNE(scrna, dims = 1:npcs, reduction = reduc)

--- a/R/clusterdeg.R
+++ b/R/clusterdeg.R
@@ -77,7 +77,7 @@
 #'
 #' @author Jared Andrews
 #'
-ClusterDEG <- function(scrna, outdir = ".", npcs = 30, res = 0.8, 
+ClusterDEG <- function(scrna, outdir = ".", npcs = 30, res = 0.8, mnn = FALSE,
   skip.sct = FALSE, min.dist = 0.3, n.neighbors = 30, regress = NULL, 
 	ccpca = FALSE, test = "wilcox", logfc.thresh = 0.25, min.pct = 0.1) {
 
@@ -96,27 +96,38 @@ ClusterDEG <- function(scrna, outdir = ".", npcs = 30, res = 0.8,
 		  reduction.name = "cc")
   }
 
+  # Change to "mnn" reduction for fastMNN integrated objects.
   message("Performing PCA/UMAP/TSNE on variable features.")
+  if (!mnn) {
+    reduc <- "pca"
+  } else {
+    reduc <- "mnn"
+  }
+  message("Using ", reduction, " reduction.")
+
   scrna <- RunPCA(scrna, npcs = npcs)
+  scrna <- RunTSNE(scrna, dims = 1:npcs, reduction = reduc)
   scrna <- RunUMAP(scrna, dims = 1:npcs, n.neighbors = n.neighbors, min.dist =
-    min.dist)
-  scrna <- RunTSNE(scrna, dims = 1:npcs)
+    min.dist, reduction = reduc)
 
   message("Performing clustering on variable features.")
-  scrna <- FindNeighbors(scrna, dims = 1:npcs)
+  scrna <- FindNeighbors(scrna, dims = 1:npcs, reduction = reduc)
 
+  # Clustering/marker finding for multiple resolutions.
   for (i in res) {
   	message(paste0("Finding cluster markers using ", i, " resolution."))
   	scrna <- FindClusters(scrna, resolution = i)
-  	scrna[[sprintf("Clusters.%.1fRes.%dPC", i, npcs)]] <- Idents(scrna) 
+  	scrna[[sprintf("Clusters.%.1fRes.%dPC.%s", i, npcs, reduc)]] <- 
+      Idents(scrna) 
   
 	  markers <- FindAllMarkers(scrna, assay = "RNA", 
 			logfc.threshold = logfc.thresh, min.pct = min.pct, test.use = test)
 		
 	   # Save markers as table.
 	  message("Saving cluster markers.")
-	  write.table(markers, file = sprintf("%s/Cluster.Markers.%.1fRes.%dPC.txt", 
-	  	outdir, i, npcs), sep = "\t", quote = FALSE, row.names = FALSE)
+	  write.table(markers, 
+      file = sprintf("%s/Cluster.Markers.%.1fRes.%dPC.%s.txt", 
+	  	outdir, i, npcs, reduc), sep = "\t", quote = FALSE, row.names = FALSE)
 
 	  message("Visualizing cluster markers.")
 	  top10up <- markers %>% dplyr::group_by(cluster) %>% 
@@ -124,8 +135,8 @@ ClusterDEG <- function(scrna, outdir = ".", npcs = 30, res = 0.8,
 	  # Make marker heatmap. Dynamic sizing.
 	  h <- 4 + (0.15 * length(top10up$gene))
 		w <- 3 + (0.4 * length(sort(unique(Idents(scrna)))))
-	  pdf(sprintf("%s/Top10.UpMarkers.Cluster.%.1fRes.%dPC.Heatmap.pdf", outdir, 
-	  	i, npcs), height = h, width = w)
+	  pdf(sprintf("%s/Top10.UpMarkers.Cluster.%.1fRes.%dPC.%s.Heatmap.pdf", 
+      outdir, i, npcs, reduc), height = h, width = w)
 	  p <- DoHeatmap(subset(scrna, downsample = 100), features = top10up$gene, 
       assay = "RNA")
     print(p)

--- a/R/eda.R
+++ b/R/eda.R
@@ -48,9 +48,9 @@ RunQC <- function(scrna, outdir = NULL) {
 #' @param scrna \linkS4class{Seurat} object to score cell cycle genes for each 
 #'   cell.
 #' @param skip.sct Boolean indicating whether to skip \code{SCTransform} call.
-#'   Useful for integrated objects.
-#' @return \linkS4class{Seurat} object with cell cycle scores ('S.Score', 
-#'   G2M.Score') and Phase' added to \code{meta.data} for each cell.
+#'   Useful for integrated/already normalized objects.
+#' @return \linkS4class{Seurat} object with cell cycle scores ("S.Score", 
+#'   "G2M.Score") and "Phase" added to \code{meta.data} for each cell.
 #'
 #' @importFrom Seurat NormalizeData CellCycleScoring
 #'
@@ -76,7 +76,7 @@ NormScoreCC <- function(scrna, skip.sct = NULL) {
   }
 
 	cc.seurat <- CellCycleScoring(scrna, s.features = s.genes, 
-		g2m.features = g2m.genes)
+		g2m.features = g2m.genes, assay = "RNA")
 	message("Cell cycle scoring complete.")
 
 	return(cc.seurat)

--- a/R/integrate.R
+++ b/R/integrate.R
@@ -24,10 +24,10 @@
 #'   \code{RunFastMNN}.
 #' @param vars.to.regress Vector of meta.data variables to be regressed out
 #'   during \code{\link[Seurat]{SCTransform}}. 
-#' @param n.features Number of anchor features to use. 
+#' @param n.features Number of anchor features to use with 
+#'   \code{\link[Seurat]{SelectIntegrationFeatures}}. 
 #' @return An integrated \linkS4class{Seurat} object with technical 
 #'   variation/batch effects removed from the individual samples.
-#'
 #'
 #' @export
 #'
@@ -43,7 +43,10 @@
 SimpleIntegration <- function(scrnas, split.by = NULL, 
   method = c("Seurat", "MNN"), vars.to.regress = NULL, n.features = 3000) {
 
-	# Parameter checking.
+  # Arg check.
+  method <- match.arg(method)
+
+	# Seurat object splitting checking.
 	if (length(scrnas) > 1) {
 		for (i in 1:length(scrnas)) {
 			scrnas[[i]] <- Seurat::SCTransform(scrnas[[i]], verbose = FALSE, 
@@ -60,17 +63,21 @@ SimpleIntegration <- function(scrnas, split.by = NULL,
 		}
 	}
 
-	# Actual integration.
-	anch.features <- Seurat::SelectIntegrationFeatures(object.list = scrnas, 
-		nfeatures = n.features)
-	scrnas <- Seurat::PrepSCTIntegration(object.list = scrnas, 
-		anchor.features = anch.features, verbose = FALSE)
+  if (method == "MNN") {
+    scrna <- RunFastMNN(object.list = scrnas)
+  } else if (method == "Seurat") {
+    # Actual integration.
+    anch.features <- Seurat::SelectIntegrationFeatures(object.list = scrnas, 
+      nfeatures = n.features)
+    scrnas <- Seurat::PrepSCTIntegration(object.list = scrnas, 
+      anchor.features = anch.features, verbose = FALSE)
 
-	anchors <- Seurat::FindIntegrationAnchors(object.list = scrnas, 
-		normalization.method = "SCT", anchor.features = anch.features, 
-		verbose = FALSE)
-	scrna <- Seurat::IntegrateData(anchorset = anchors, 
-		normalization.method = "SCT", verbose = FALSE)
+    anchors <- Seurat::FindIntegrationAnchors(object.list = scrnas, 
+      normalization.method = "SCT", anchor.features = anch.features, 
+      verbose = FALSE)
+    scrna <- Seurat::IntegrateData(anchorset = anchors, 
+      normalization.method = "SCT", verbose = FALSE)
+  }
 
 	return(scrna)
 }

--- a/R/integrate.R
+++ b/R/integrate.R
@@ -64,7 +64,7 @@ SimpleIntegration <- function(scrnas, split.by = NULL,
 	}
 
   if (method == "MNN") {
-    scrna <- RunFastMNN(object.list = scrnas)
+    scrna <- RunFastMNN(object.list = scrnas, features = n.features)
   } else if (method == "Seurat") {
     # Actual integration.
     anch.features <- Seurat::SelectIntegrationFeatures(object.list = scrnas, 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,4 @@
 # Have to stupidly define these variables so as not to throw NOTES during build.
 globalVariables(c("cc.genes", "i", "cluster", "avg_logFC",
  "cdr3s_aa", "prop", "ord", "marker.df", "Term",
-	"log.Adj.p", "Combined.Score"))
+	"log.Adj.p", "Combined.Score", "RunFastMNN"))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,8 @@ environment:
   PKGTYPE: both
 
 build_script:
+  - travis-tool.sh install_bioc GenomeInfoDbData BiocParallel
   - travis-tool.sh install_bioc_deps
-  - travis-tool.sh install_bioc GenomeInfoDbData
   - travis-tool.sh install_deps
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,10 +18,9 @@ cache:
 # Need Rtools to install source dependencies
 environment:
   USE_RTOOLS: true
-  PKGTYPE: both
 
 build_script:
-  - travis-tool.sh install_bioc GenomeInfoDbData BiocParallel
+  - travis-tool.sh bioc_install GenomeInfoDbData BiocParallel SummarizedExperiment SingleCellExperiment S4Vectors
   - travis-tool.sh install_bioc_deps
   - travis-tool.sh install_deps
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ environment:
 
 build_script:
   - travis-tool.sh install_deps
+  - travis-tool.sh install_bioc_deps
 
 test_script:
   - travis-tool.sh run_tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,9 @@ environment:
   USE_RTOOLS: true
 
 build_script:
-  - travis-tool.sh install_deps
   - travis-tool.sh install_bioc_deps
+  - travis-tool.sh install_deps
+
 
 test_script:
   - travis-tool.sh run_tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ cache:
 # Need Rtools to install source dependencies
 environment:
   USE_RTOOLS: true
+  PKGTYPE: both
 
 build_script:
   - travis-tool.sh install_bioc_deps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ environment:
 
 build_script:
   - travis-tool.sh install_bioc_deps
+  - travis-tool.sh install_bioc GenomeInfoDbData
   - travis-tool.sh install_deps
 
 

--- a/man/ClusterDEG.Rd
+++ b/man/ClusterDEG.Rd
@@ -25,6 +25,11 @@ respectively. The clusters derived from the last value in the list will be
 set as the default Ident for cells and stored in \code{meta.data} under
 'seurat_clusters' in addition to the aforementioned format.}
 
+\item{mnn}{Boolean indicating whether \code{scrna} was integrated with
+\code{method="MNN"} via \code{\link{SimpleIntegration}}. If so, must be set
+to \code{TRUE} or unintegrated PCA embeddings will be used for
+dimensionality reduction and clustering.}
+
 \item{skip.sct}{Boolean indicating whether to skip 
 \code{\link[Seurat]{SCTransform}}. Set to TRUE if 
 \code{\link{SimpleIntegration}} was used to integrate the 

--- a/man/ClusterDEG.Rd
+++ b/man/ClusterDEG.Rd
@@ -4,7 +4,7 @@
 \alias{ClusterDEG}
 \title{Normalize, scale, and regress out wanted variation}
 \usage{
-ClusterDEG(scrna, outdir = ".", npcs = 30, res = 0.8,
+ClusterDEG(scrna, outdir = ".", npcs = 30, res = 0.8, mnn = FALSE,
   skip.sct = FALSE, min.dist = 0.3, n.neighbors = 30,
   regress = NULL, ccpca = FALSE, test = "wilcox",
   logfc.thresh = 0.25, min.pct = 0.1)

--- a/man/NormScoreCC.Rd
+++ b/man/NormScoreCC.Rd
@@ -11,11 +11,11 @@ NormScoreCC(scrna, skip.sct = NULL)
 cell.}
 
 \item{skip.sct}{Boolean indicating whether to skip \code{SCTransform} call.
-Useful for integrated objects.}
+Useful for integrated/already normalized objects.}
 }
 \value{
-\linkS4class{Seurat} object with cell cycle scores ('S.Score', 
-  G2M.Score') and Phase' added to \code{meta.data} for each cell.
+\linkS4class{Seurat} object with cell cycle scores ("S.Score", 
+  "G2M.Score") and "Phase" added to \code{meta.data} for each cell.
 }
 \description{
 \code{NormScoreCC} returns a \code{Seurat} object with normalized counts and 

--- a/man/SimpleIntegration.Rd
+++ b/man/SimpleIntegration.Rd
@@ -22,7 +22,8 @@ internal functions for SCT integration. "MNN" will use
 \item{vars.to.regress}{Vector of meta.data variables to be regressed out
 during \code{\link[Seurat]{SCTransform}}.}
 
-\item{n.features}{Number of anchor features to use.}
+\item{n.features}{Number of anchor features to use with 
+\code{\link[Seurat]{SelectIntegrationFeatures}}.}
 }
 \value{
 An integrated \linkS4class{Seurat} object with technical 


### PR DESCRIPTION
 - Add option to integrate using `fastMNN` from `batchelor` by using the `RunFastMNN` function from `SeuratWrappers`. Seems a touch more intelligent than Seurat's method and has some diagnostic metrics that help determine whether biological heterogeneity is being blown away. And allow you to define the merge order.
 - Also fixes all the CI tests.